### PR TITLE
feat: add support for transformers and server side syntax highlight

### DIFF
--- a/app/Bark/Core.hs
+++ b/app/Bark/Core.hs
@@ -6,7 +6,7 @@ where
 
 import Bark.FrontMatter (parseString)
 import Bark.Internal.IOUtil (Result, tryReadFileT, withFilesInDir)
-import Bark.Preprocess (applyTransformers, highLightSnippets)
+import Bark.Transformers (applyTransformers, highLightSnippets)
 import Commonmark (Html, ParseError, commonmarkWith, defaultSyntaxSpec, renderHtml)
 import Commonmark.Extensions (gfmExtensions)
 import Control.Arrow (ArrowChoice (left))
@@ -14,7 +14,6 @@ import Control.Monad (when)
 import Data.Functor.Identity (Identity, runIdentity)
 import Data.HashMap.Strict as HashMap ((!))
 import Data.List (stripPrefix)
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO

--- a/app/Bark/FrontMatter.hs
+++ b/app/Bark/FrontMatter.hs
@@ -5,7 +5,7 @@ module Bark.FrontMatter (tokenize, Token (..), parseString, parseFromTokens) whe
 import qualified Data.Bifunctor as Bifunctor
 import Data.Char (isAlphaNum, isSpace)
 import Data.HashMap.Strict (HashMap, empty, insert)
-import Data.Text as T (Text, pack)
+import qualified Data.Text as T 
 import qualified Data.Vector as Vec (fromList)
 import Text.Mustache.Types (Value (..))
 
@@ -59,9 +59,9 @@ parseList acc tokens =
         Left errMsg -> Left errMsg
     [] -> Left "Expected ']' to close list, but found end of input"
 
-type MetaMapEntry = (Text, Value)
+type MetaMapEntry = (T.Text, Value)
 
-type MetaMap = HashMap Text Value
+type MetaMap = HashMap T.Text Value
 
 parseMapEntry :: [Token] -> Either ParseError (MetaMapEntry, [Token])
 parseMapEntry [TKey key] =

--- a/app/Bark/Preprocess.hs
+++ b/app/Bark/Preprocess.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Bark.Preprocess (TransFormer, applyTransformers, highLightSnippets) where
+
+import qualified Data.List as L
+import Data.Map ((!))
+import qualified Data.Maybe as M
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Skylighting
+import qualified Skylighting as Fmt
+import Text.Blaze.Html.Renderer.Text (renderHtml)
+import qualified Text.HTML.TagSoup as H
+
+getTokensFromText :: T.Text -> T.Text -> Either String [Fmt.SourceLine]
+getTokensFromText langName text =
+  let syntax =
+        M.fromMaybe
+          (defaultSyntaxMap ! T.pack "Default")
+          (Fmt.lookupSyntax langName defaultSyntaxMap)
+      tokenizerConfig =
+        Fmt.TokenizerConfig
+          { Fmt.syntaxMap = defaultSyntaxMap,
+            Fmt.traceOutput = False
+          }
+   in tokenize tokenizerConfig syntax text
+
+highlightBlock :: [H.Attribute T.Text] -> T.Text -> Either String [H.Tag T.Text]
+highlightBlock attrs code =
+  let langAttr = L.find (T.isPrefixOf "language-" . snd) attrs
+      language = maybe "language-default" snd langAttr
+      syntaxMapKey = M.fromJust $ T.stripPrefix "language-" language
+      tokens = getTokensFromText syntaxMapKey code
+      html = Fmt.formatHtmlBlock defaultFormatOpts <$> tokens
+      renderedHtml = renderHtml <$> html
+      parsedHtml = H.parseTags . TL.toStrict <$> renderedHtml
+   in parsedHtml
+
+type TransFormer = [H.Tag T.Text] -> [H.Tag T.Text]
+
+highLightSnippets :: TransFormer
+highLightSnippets = go
+  where
+    go :: [H.Tag T.Text] -> [H.Tag T.Text]
+    go (open@(H.TagOpen "code" attrs) : (H.TagText txt) : rest) =
+      case highlightBlock attrs txt of
+        Left foo -> error foo
+        Right tags -> (open : tags) ++ go rest
+    go (x : other) = x : go other
+    go [] = []
+
+applyTransformers :: [TransFormer] -> T.Text -> T.Text
+applyTransformers [] f = f
+applyTransformers funcs html =
+  let ast = H.parseTags html
+      finalAst = go funcs ast
+   in H.renderTags finalAst
+  where
+    go :: [TransFormer] -> [H.Tag T.Text] -> [H.Tag T.Text]
+    go [] tags = tags
+    go (f : fs) tags = go fs (f tags)

--- a/bark.cabal
+++ b/bark.cabal
@@ -57,7 +57,7 @@ library
     exposed-modules:
         Bark.Core,
         Bark.FrontMatter,
-        Bark.Preprocess
+        Bark.Transformers
 
 
 executable bark
@@ -67,7 +67,7 @@ executable bark
     other-modules:
         Bark.Core,
         Bark.FrontMatter,
-        Bark.Preprocess
+        Bark.Transformers
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
     build-depends:

--- a/bark.cabal
+++ b/bark.cabal
@@ -37,7 +37,7 @@ library bark-internal
 library
     hs-source-dirs: app
     build-depends:
-        base ^>=4.14.3.0,
+        base,
         bark:bark-internal,
         commonmark,
         commonmark-extensions,
@@ -49,11 +49,15 @@ library
         unordered-containers,
         vector,
         fsnotify,
-        dir-traverse
+        dir-traverse,
+        skylighting,
+        tagsoup,
+        blaze-html
 
     exposed-modules:
         Bark.Core,
-        Bark.FrontMatter
+        Bark.FrontMatter,
+        Bark.Preprocess
 
 
 executable bark
@@ -62,11 +66,12 @@ executable bark
     -- Modules included in this executable, other than Main.
     other-modules:
         Bark.Core,
-        Bark.FrontMatter
+        Bark.FrontMatter,
+        Bark.Preprocess
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
     build-depends:
-        base ^>=4.14.3.0,
+        base,
         text,
         commonmark,
         commonmark-extensions,
@@ -77,7 +82,10 @@ executable bark
         unordered-containers,
         vector,
         fsnotify,
-        dir-traverse
+        dir-traverse,
+        skylighting,
+        tagsoup,
+        blaze-html
 
     ghc-options:
         -threaded

--- a/build_site.sh
+++ b/build_site.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -rf docs
 cd site
 bark build

--- a/docs/css/syntax.css
+++ b/docs/css/syntax.css
@@ -1,0 +1,61 @@
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; left: -4em; }
+pre.numberSource a.sourceLine::before
+  { content: attr(title);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,60 +20,60 @@
 <p>If you have any experience with Hugo, 11ty or Jekyll then using Bark should be a cakewalk.</p>
 <h2 id="installation">Installation</h2>
 <p>Since bark is in it&#39;s experimental stages, the only way to get it currently is to
-compile it from source. The source tree can be found <a href="https://github.com/srijan-paul/bark">here</a> on GitHub. Just clone the repo and run the <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>build.sh</span></code></pre></div></code> script to compile.
-When finished, you should see an executable in <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>dist/bark</span></code></pre></div></code>.</p>
+compile it from source. The source tree can be found <a href="https://github.com/srijan-paul/bark">here</a> on GitHub. Just clone the repo and run the <code>build.sh</code> script to compile.
+When finished, you should see an executable in <code>dist/bark</code>.</p>
 <p>Once it&#39;s more stable, bark will be released on hackage.</p>
 <h2 id="usage">Usage</h2>
 <p>Using bark is as simple as it gets.</p>
 <h3 id="one-time-setup">One time setup</h3>
 <p>You&#39;ll need <a href="https://www.haskell.org/cabal/">cabal</a> and <a href="https://www.haskell.org/ghc/">ghc</a> installed to
 install bark. Once you&#39;ve made sure you have them installed, clone the GitHub repository and run this command:</p>
-<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cabal install exe:bark <span class="at">--overwrite-policy</span><span class="op">=</span>always</span></code></pre></div></code></pre>
+<code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cabal install exe:bark <span class="at">--overwrite-policy</span><span class="op">=</span>always</span></code></pre></div></code></pre>
 <p>Let&#39;s do a quick sanity check to ensure all&#39;s good.
-If you get something similar to what&#39;s shown below when you enter <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>bark</span></code></pre></div></code> into the command line, then we&#39;re all set!</p>
-<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark</span>
+If you get something similar to what&#39;s shown below when you enter <code>bark</code> into the command line, then we&#39;re all set!</p>
+<code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark</span>
 <span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a><span class="ex">Bark</span> v0.1.0. commands available:</span>
 <span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a><span class="ex">build:</span> build the current project</span>
 <span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a><span class="ex">watch:</span> watch the directory and build whenever changes are detected.</span></code></pre></div></code></pre>
 <h3 id="creating-projects">Creating projects</h3>
-<p>To create a new project, create an empty directory and initialize it with <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>bark init</span></code></pre></div></code>.</p>
-<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> mkdir project</span>
+<p>To create a new project, create an empty directory and initialize it with <code>bark init</code>.</p>
+<code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> mkdir project</span>
 <span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cd project</span>
 <span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark init</span></code></pre></div></code></pre>
 <p>Now your directory should have this structure:</p>
-<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="bu">.</span></span>
+<code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="bu">.</span></span>
 <span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a><span class="ex">├──</span> src</span>
 <span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a><span class="ex">│</span>   ├── assets</span>
 <span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a><span class="ex">│</span>   ├── content</span>
 <span id="5"><a href="#5" aria-hidden="true" tabindex="-1"></a><span class="ex">│</span>   └── public</span>
 <span id="6"><a href="#6" aria-hidden="true" tabindex="-1"></a><span class="ex">└──</span> template</span></code></pre></div></code></pre>
 <h3 id="adding-new-posts">Adding new posts</h3>
-<p>To add a new post, you&#39;ll have to create two new files in the <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>content</span></code></pre></div></code> directory.</p>
-<pre><code class="language-shell"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>$ touch src/content/post.md src/content/post.meta</span></code></pre></div></code></pre>
-<p>The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.md</span></code></pre></div></code> file contains the markdown content of our page.
-The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.meta</span></code></pre></div></code> file contains metadata about our post.
+<p>To add a new post, you&#39;ll have to create two new files in the <code>content</code> directory.</p>
+<code class="language-shell"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>$ touch src/content/post.md src/content/post.meta</span></code></pre></div></code></pre>
+<p>The <code>post.md</code> file contains the markdown content of our page.
+The <code>post.meta</code> file contains metadata about our post.
 The metadata is stored in a JSON-like format.</p>
-<p>Here&#39;s an example of what you could write into <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.md</span></code></pre></div></code>:</p>
-<pre><code class="language-markdown"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Hello, world!</span></span>
+<p>Here&#39;s an example of what you could write into <code>post.md</code>:</p>
+<code class="language-markdown"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Hello, world!</span></span>
 <span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a>This is my first post</span></code></pre></div></code></pre>
-<p>And the corresponding metadata in a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.meta</span></code></pre></div></code> file:</p>
-<pre><code class="language-javascript"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>{</span>
+<p>And the corresponding metadata in a <code>post.meta</code> file:</p>
+<code class="language-javascript"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>{</span>
 <span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a>    <span class="dt">date</span><span class="op">:</span> <span class="st">&quot;17th December 2021&quot;</span></span>
 <span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">tags</span><span class="op">:</span> [<span class="st">&quot;post&quot;</span> <span class="st">&quot;blog&quot;</span>]</span>
 <span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">template</span><span class="op">:</span> <span class="st">&quot;post&quot;</span></span>
 <span id="5"><a href="#5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">title</span><span class="op">:</span> <span class="st">&quot;My first post!&quot;</span></span>
 <span id="6"><a href="#6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div></code></pre>
-<p>The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>template</span></code></pre></div></code> key is special, and <strong>must</strong> be present in a metadata file.
+<p>The <code>template</code> key is special, and <strong>must</strong> be present in a metadata file.
 It represents which HTML template to use when rendering the post.</p>
 <h3 id="using-templates">Using templates</h3>
 <p>A bark template is written in the <a href="https://mustache.github.io/">mustache</a> templating language.
 If you&#39;ve used HTML, then you already know most of what you need to know.
 In the mustache template, there are some prexisting variables.</p>
-<p>The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>content</span></code></pre></div></code> is a string containing the markdown content of the page, now converted to HTML.
-The other global variables correspond to the keys listed in a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>.meta</span></code></pre></div></code> file.</p>
-<p>Here is an example template, <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.mustache</span></code></pre></div></code>:</p>
-<pre><code class="language-html"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;html&gt;</span></span>
+<p>The <code>content</code> is a string containing the markdown content of the page, now converted to HTML.
+The other global variables correspond to the keys listed in a <code>.meta</code> file.</p>
+<p>Here is an example template, <code>post.mustache</code>:</p>
+<code class="language-html"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;html&gt;</span></span>
 <span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">&lt;head&gt;</span></span>
 <span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a>    <span class="co">&lt;!-- This will be replaced with the `title` key in the `.meta` file.  --&gt;</span></span>
 <span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">&lt;title&gt;</span>{{ title }}<span class="kw">&lt;/title&gt;</span></span>
@@ -90,11 +90,11 @@ The other global variables correspond to the keys listed in a <code><div class="
 <span id="15"><a href="#15" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;/html&gt;</span></span></code></pre></div></code></pre>
 <h3 id="building-your-project">Building your project</h3>
 <p>This is where everything comes together nicely.</p>
-<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark build</span></code></pre></div></code></pre>
-<p>Once you do this, you should see a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>build</span></code></pre></div></code> directory pop up in the project root.
+<code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark build</span></code></pre></div></code></pre>
+<p>Once you do this, you should see a <code>build</code> directory pop up in the project root.
 This directory now contains the HTML output of all our files.</p>
 <p>Running the build command again and again is tedious.
-You could make bark watch over the directory for changes using <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>bark watch</span></code></pre></div></code>.</p>
+You could make bark watch over the directory for changes using <code>bark watch</code>.</p>
 <h2 id="sample-project">Sample project.</h2>
 <p>Want a sample project as reference? How about this one?</p>
 <p>The page you&#39;re reading right now has been made with bark.
@@ -102,9 +102,9 @@ You can find the source <a href="https://github.com/srijan-paul/bark/tree/main/s
 <h2 id="faq">FAQ</h2>
 <p><strong>Q. How can I get syntax highlighting?</strong></p>
 <p>Same way I did on this page.
-You could use a syntax highlighting library like <a href="https://highlightjs.org/">highlight.js</a> and initialize it in a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>&lt;script&gt;</span></code></pre></div></code> tag in your template to embed it. It only takes 5 lines of code!</p>
+You could use a syntax highlighting library like <a href="https://highlightjs.org/">highlight.js</a> and initialize it in a <code>&lt;script&gt;</code> tag in your template to embed it. It only takes 5 lines of code!</p>
 <p><strong>Q. How can do I get nested/grouped paths to my pages?</strong></p>
-<p>Simple! Just nest your directory structure inside <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>content</span></code></pre></div></code> the way you want your URLs to turn out.
+<p>Simple! Just nest your directory structure inside <code>content</code> the way you want your URLs to turn out.
 The build directory structure mirrors the source.</p>
 <p><strong>Q. Does bark support images and other media content?</strong></p>
 <p><img src="assets/cookedcat.jpg" alt="cat-image"></img></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css">
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
+  <link rel="stylesheet" href="css/syntax.css">
+  <!--<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css">-->
+  <!--<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>-->
   <title>Bark - SSG in Haskell</title>
 </head>
 
@@ -18,115 +19,106 @@
 <p>Bark is a static site generator written in Haskell, targeting ease of use.</p>
 <p>If you have any experience with Hugo, 11ty or Jekyll then using Bark should be a cakewalk.</p>
 <h2 id="installation">Installation</h2>
-<p>Since bark is in it's experimental stages, the only way to get it currently is to
-compile it from source. The source tree can be found <a href="https://github.com/srijan-paul/bark">here</a> on GitHub. Just clone the repo and run the <code>build.sh</code> script to compile.
-When finished, you should see an executable in <code>dist/bark</code>.</p>
-<p>Once it's more stable, bark will be released on hackage.</p>
+<p>Since bark is in it&#39;s experimental stages, the only way to get it currently is to
+compile it from source. The source tree can be found <a href="https://github.com/srijan-paul/bark">here</a> on GitHub. Just clone the repo and run the <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>build.sh</span></code></pre></div></code> script to compile.
+When finished, you should see an executable in <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>dist/bark</span></code></pre></div></code>.</p>
+<p>Once it&#39;s more stable, bark will be released on hackage.</p>
 <h2 id="usage">Usage</h2>
 <p>Using bark is as simple as it gets.</p>
 <h3 id="one-time-setup">One time setup</h3>
-<p>You'll need <a href="https://www.haskell.org/cabal/">cabal</a> and <a href="https://www.haskell.org/ghc/">ghc</a> installed to
-install bark. Once you've made sure you have them installed, clone the GitHub repository and run this command:</p>
-<pre><code class="language-sh">$ cabal install exe:bark --overwrite-policy=always
-</code></pre>
-<p>Let's do a quick sanity check to ensure all's good.
-If you get something similar to what's shown below when you enter <code>bark</code> into the command line, then we're all set!</p>
-<pre><code class="language-sh">$ bark
-Bark v0.1.0. commands available:
-build: build the current project
-watch: watch the directory and build whenever changes are detected.
-</code></pre>
+<p>You&#39;ll need <a href="https://www.haskell.org/cabal/">cabal</a> and <a href="https://www.haskell.org/ghc/">ghc</a> installed to
+install bark. Once you&#39;ve made sure you have them installed, clone the GitHub repository and run this command:</p>
+<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cabal install exe:bark <span class="at">--overwrite-policy</span><span class="op">=</span>always</span></code></pre></div></code></pre>
+<p>Let&#39;s do a quick sanity check to ensure all&#39;s good.
+If you get something similar to what&#39;s shown below when you enter <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>bark</span></code></pre></div></code> into the command line, then we&#39;re all set!</p>
+<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark</span>
+<span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a><span class="ex">Bark</span> v0.1.0. commands available:</span>
+<span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a><span class="ex">build:</span> build the current project</span>
+<span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a><span class="ex">watch:</span> watch the directory and build whenever changes are detected.</span></code></pre></div></code></pre>
 <h3 id="creating-projects">Creating projects</h3>
-<p>To create a new project, create an empty directory and initialize it with <code>bark init</code>.</p>
-<pre><code class="language-sh">$ mkdir project
-$ cd project
-$ bark init
-</code></pre>
+<p>To create a new project, create an empty directory and initialize it with <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>bark init</span></code></pre></div></code>.</p>
+<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> mkdir project</span>
+<span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cd project</span>
+<span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark init</span></code></pre></div></code></pre>
 <p>Now your directory should have this structure:</p>
-<pre><code class="language-sh">.
-├── src
-│   ├── assets
-│   ├── content
-│   └── public
-└── template
-</code></pre>
+<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="bu">.</span></span>
+<span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a><span class="ex">├──</span> src</span>
+<span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a><span class="ex">│</span>   ├── assets</span>
+<span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a><span class="ex">│</span>   ├── content</span>
+<span id="5"><a href="#5" aria-hidden="true" tabindex="-1"></a><span class="ex">│</span>   └── public</span>
+<span id="6"><a href="#6" aria-hidden="true" tabindex="-1"></a><span class="ex">└──</span> template</span></code></pre></div></code></pre>
 <h3 id="adding-new-posts">Adding new posts</h3>
-<p>To add a new post, you'll have to create two new files in the <code>content</code> directory.</p>
-<pre><code class="language-sh">$ touch src/content/post.md src/content/post.meta
-</code></pre>
-<p>The <code>post.md</code> file contains the markdown content of our page.
-The <code>post.meta</code> file contains metadata about our post.
+<p>To add a new post, you&#39;ll have to create two new files in the <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>content</span></code></pre></div></code> directory.</p>
+<pre><code class="language-shell"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>$ touch src/content/post.md src/content/post.meta</span></code></pre></div></code></pre>
+<p>The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.md</span></code></pre></div></code> file contains the markdown content of our page.
+The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.meta</span></code></pre></div></code> file contains metadata about our post.
 The metadata is stored in a JSON-like format.</p>
-<p>Here's an example of what you could write into <code>post.md</code>:</p>
-<pre><code class="language-md"># Hello, world!
-
-This is my first post
-</code></pre>
-<p>And the corresponding metadata in a <code>post.meta</code> file:</p>
-<pre><code class="language-js">{
-    date: &quot;17th December 2021&quot;
-    tags: [&quot;post&quot; &quot;blog&quot;]
-    template: &quot;post&quot;
-    title: &quot;My first post!&quot;
-}
-</code></pre>
-<p>The <code>template</code> key is special, and <strong>must</strong> be present in a metadata file.
+<p>Here&#39;s an example of what you could write into <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.md</span></code></pre></div></code>:</p>
+<pre><code class="language-markdown"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Hello, world!</span></span>
+<span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a>This is my first post</span></code></pre></div></code></pre>
+<p>And the corresponding metadata in a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.meta</span></code></pre></div></code> file:</p>
+<pre><code class="language-javascript"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a>    <span class="dt">date</span><span class="op">:</span> <span class="st">&quot;17th December 2021&quot;</span></span>
+<span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">tags</span><span class="op">:</span> [<span class="st">&quot;post&quot;</span> <span class="st">&quot;blog&quot;</span>]</span>
+<span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">template</span><span class="op">:</span> <span class="st">&quot;post&quot;</span></span>
+<span id="5"><a href="#5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">title</span><span class="op">:</span> <span class="st">&quot;My first post!&quot;</span></span>
+<span id="6"><a href="#6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div></code></pre>
+<p>The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>template</span></code></pre></div></code> key is special, and <strong>must</strong> be present in a metadata file.
 It represents which HTML template to use when rendering the post.</p>
 <h3 id="using-templates">Using templates</h3>
 <p>A bark template is written in the <a href="https://mustache.github.io/">mustache</a> templating language.
-If you've used HTML, then you already know most of what you need to know.
+If you&#39;ve used HTML, then you already know most of what you need to know.
 In the mustache template, there are some prexisting variables.</p>
-<p>The <code>content</code> is a string containing the markdown content of the page, now converted to HTML.
-The other global variables correspond to the keys listed in a <code>.meta</code> file.</p>
-<p>Here is an example template, <code>post.mustache</code>:</p>
-<pre><code class="language-html">&lt;html&gt;
-  &lt;head&gt;
-    &lt;!-- This will be replaced with the `title` key in the `.meta` file.  --&gt;
-    &lt;title&gt;{{ title }}&lt;/title&gt;
-  &lt;/head&gt;
-  &lt;body&gt;
-    &lt;div class=&quot;main&quot;&gt;
-      &lt;!-- replaced by the `date` key in the `.meta` file --&gt;
-      Date: {{ date }} 
-      &lt;!-- The '&amp;' is neccessary when plugging in HTML,
-           otherwise the output will be sanitized, hence escaping the `&lt;` and `&gt;` characters --&gt;
-      {{&amp;content}}
-    &lt;/div&gt;
-  &lt;/body&gt;
-&lt;/html&gt;
-</code></pre>
+<p>The <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>content</span></code></pre></div></code> is a string containing the markdown content of the page, now converted to HTML.
+The other global variables correspond to the keys listed in a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>.meta</span></code></pre></div></code> file.</p>
+<p>Here is an example template, <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>post.mustache</span></code></pre></div></code>:</p>
+<pre><code class="language-html"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;html&gt;</span></span>
+<span id="2"><a href="#2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">&lt;head&gt;</span></span>
+<span id="3"><a href="#3" aria-hidden="true" tabindex="-1"></a>    <span class="co">&lt;!-- This will be replaced with the `title` key in the `.meta` file.  --&gt;</span></span>
+<span id="4"><a href="#4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">&lt;title&gt;</span>{{ title }}<span class="kw">&lt;/title&gt;</span></span>
+<span id="5"><a href="#5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">&lt;/head&gt;</span></span>
+<span id="6"><a href="#6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">&lt;body&gt;</span></span>
+<span id="7"><a href="#7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">&lt;div</span> <span class="er">class</span><span class="ot">=</span><span class="st">&quot;main&quot;</span><span class="kw">&gt;</span></span>
+<span id="8"><a href="#8" aria-hidden="true" tabindex="-1"></a>      <span class="co">&lt;!-- replaced by the `date` key in the `.meta` file --&gt;</span></span>
+<span id="9"><a href="#9" aria-hidden="true" tabindex="-1"></a>      Date: {{ date }} </span>
+<span id="10"><a href="#10" aria-hidden="true" tabindex="-1"></a>      <span class="co">&lt;!-- The &#39;&amp;&#39; is neccessary when plugging in HTML,</span></span>
+<span id="11"><a href="#11" aria-hidden="true" tabindex="-1"></a><span class="co">           otherwise the output will be sanitized, hence escaping the `&lt;` and `&gt;` characters --&gt;</span></span>
+<span id="12"><a href="#12" aria-hidden="true" tabindex="-1"></a>      {{<span class="er">&amp;</span>content}}</span>
+<span id="13"><a href="#13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">&lt;/div&gt;</span></span>
+<span id="14"><a href="#14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">&lt;/body&gt;</span></span>
+<span id="15"><a href="#15" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;/html&gt;</span></span></code></pre></div></code></pre>
 <h3 id="building-your-project">Building your project</h3>
 <p>This is where everything comes together nicely.</p>
-<pre><code class="language-sh">$ bark build
-</code></pre>
-<p>Once you do this, you should see a <code>build</code> directory pop up in the project root.
+<pre><code class="language-sh"><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> bark build</span></code></pre></div></code></pre>
+<p>Once you do this, you should see a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>build</span></code></pre></div></code> directory pop up in the project root.
 This directory now contains the HTML output of all our files.</p>
 <p>Running the build command again and again is tedious.
-You could make bark watch over the directory for changes using <code>bark watch</code>.</p>
+You could make bark watch over the directory for changes using <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>bark watch</span></code></pre></div></code>.</p>
 <h2 id="sample-project">Sample project.</h2>
 <p>Want a sample project as reference? How about this one?</p>
-<p>The page you're reading right now has been made with bark.
+<p>The page you&#39;re reading right now has been made with bark.
 You can find the source <a href="https://github.com/srijan-paul/bark/tree/main/site">here</a>.</p>
 <h2 id="faq">FAQ</h2>
 <p><strong>Q. How can I get syntax highlighting?</strong></p>
 <p>Same way I did on this page.
-You could use a syntax highlighting library like <a href="https://highlightjs.org/">highlight.js</a> and initialize it in a <code>&lt;script&gt;</code> tag in your template to embed it. It only takes 5 lines of code!</p>
+You could use a syntax highlighting library like <a href="https://highlightjs.org/">highlight.js</a> and initialize it in a <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>&lt;script&gt;</span></code></pre></div></code> tag in your template to embed it. It only takes 5 lines of code!</p>
 <p><strong>Q. How can do I get nested/grouped paths to my pages?</strong></p>
-<p>Simple! Just nest your directory structure inside <code>content</code> the way you want your URLs to turn out.
+<p>Simple! Just nest your directory structure inside <code><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span id="1"><a href="#1" aria-hidden="true" tabindex="-1"></a>content</span></code></pre></div></code> the way you want your URLs to turn out.
 The build directory structure mirrors the source.</p>
 <p><strong>Q. Does bark support images and other media content?</strong></p>
-<p><img src="assets/cookedcat.jpg" alt="cat-image" /></p>
-<p><strong>Q. My question isn't listed here !</strong></p>
+<p><img src="assets/cookedcat.jpg" alt="cat-image"></img></p>
+<p><strong>Q. My question isn&#39;t listed here !</strong></p>
 <p>You can always file an <a href="https://github.com/srijan-paul/bark/issues">issue</a> to submit bugs/suggestions,
 or get in touch with me on my <a href="https://twitter.com/_injuly">twitter</a> or discord - <strong>injuly#6820</strong>.</p>
-<h2 id="thats-it">That's it!</h2>
-<p>You've done it.</p>
-<p>You've mastered SSGs.</p>
+<h2 id="thats-it">That&#39;s it!</h2>
+<p>You&#39;ve done it.</p>
+<p>You&#39;ve mastered SSGs.</p>
 <p>Now go make some beautiful webpages, unlike this one.</p>
 
   </div>
 
-  <script>hljs.highlightAll();</script>
+  <!--<script>hljs.highlightAll();</script>-->
 </body>
 
 </html>

--- a/site/src/content/index.md
+++ b/site/src/content/index.md
@@ -60,7 +60,7 @@ Now your directory should have this structure:
 
 To add a new post, you'll have to create two new files in the `content` directory.
 
-```sh
+```shell
 $ touch src/content/post.md src/content/post.meta
 ```
 
@@ -70,7 +70,7 @@ The metadata is stored in a JSON-like format.
 
 Here's an example of what you could write into `post.md`:
 
-```md
+```markdown
 # Hello, world!
 
 This is my first post
@@ -78,7 +78,7 @@ This is my first post
 
 And the corresponding metadata in a `post.meta` file:
 
-```js
+```javascript
 {
     date: "17th December 2021"
     tags: ["post" "blog"]

--- a/site/src/css/syntax.css
+++ b/site/src/css/syntax.css
@@ -1,0 +1,61 @@
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; left: -4em; }
+pre.numberSource a.sourceLine::before
+  { content: attr(title);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */

--- a/site/template/post.mustache
+++ b/site/template/post.mustache
@@ -6,8 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css">
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
+  <link rel="stylesheet" href="css/syntax.css">
+  <!--<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css">-->
+  <!--<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>-->
   <title>{{meta.title}}</title>
 </head>
 
@@ -17,7 +18,7 @@
     {{&content}}
   </div>
 
-  <script>hljs.highlightAll();</script>
+  <!--<script>hljs.highlightAll();</script>-->
 </body>
 
 </html>


### PR DESCRIPTION
Prior this to PR, syntax highlighting was done **after** the webpage was loaded on the browser.
The template would have to use highlight.js's CDN, and have a script tag somewhere that called `hljs.highlightAll()`.
This method had some obvious drawbacks:
- 40+kB of JavaScript being sent to the browser, for hljs core library and hlhs syntax definitions.
- Running code on the client side for JavaScript didn't feel right. Some like to disable scripts when loading a web-page. The user should not have to suffer the sight of black-and-white code snippets just because they don't want websites running JavaScript.

This PR introduces the concept of transformers.
A Transformer takes an HTML AST (a list of tags), and returns a new AST.
A Syntax highlighter transformer, for instance, will take a regular HTML tag list, find any text inside "code" tags, and replace that text with a list of different tags. These tags add html class names to different tokens of the code snippet. These class names can then be used by a CSS file for syntax highlighting.

Transformers that can be added in the future include date time manipulation, and LaTeX rendering.

I'm using the skylighting library for syntax highlight, tagsoup for parsing and rendering HTML, and blaze-html as a bridge between tagsoup and skylighting. This introduces some redundant parse and unparse steps, but I don't think the performance drop is significant enough for me to bother with this. I'll probably think about optimizing this later.

In a follow up PR, users will be able to define their own transformers.